### PR TITLE
ci: AI 리뷰 워크플로 자기취소 방지 (v1.0.1)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -9,7 +9,9 @@ on:
     types: [created]
 
 concurrency:
-  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  # 이벤트별로 그룹을 분리해, 코멘트로 트리거된 실행이 진행 중인 PR 리뷰 실행을
+  # 취소(자기취소 → 빨간 체크)하지 않도록 한다. (ai-code-review-action#7)
+  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:
@@ -19,12 +21,15 @@ permissions:
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.draft != true) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.type != 'Bot')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: damdam6/ai-code-review-action@v1.0.0
+      - uses: damdam6/ai-code-review-action@v1.0.1
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           google-api-key: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
## 문제
`AI Code Review` 워크플로가 `pull_request`와 `issue_comment` 양쪽에 반응하는데, concurrency 그룹이 PR 번호만으로 묶여 있어 **액션이 PR에 코멘트를 달면 그 `issue_comment` 실행이 진행 중인 `pull_request` 리뷰 실행을 취소**했다. 결과적으로 PR에 빨간 `review` 체크가 뜸(실제 리뷰는 별도 실행에서 성공). #59에서 재현됨.

## 수정 (ai-code-review-action v1.0.1, #7)
- concurrency group을 **이벤트별로 분리** (`...-${{ github.event_name }}`) → 코멘트 실행이 PR 실행을 더 이상 취소하지 않음
- job `if`에 **봇 코멘트 제외** + `issue_comment`는 PR에 한정
- 액션 `@v1.0.0` → **`@v1.0.1`**

## 참고
`issue_comment` 트리거 실행은 항상 기본 브랜치(main)의 워크플로를 사용하므로, 이 픽스는 main 머지 후 완전히 적용된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)